### PR TITLE
update: remove default arguments for username and icon_emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You can customize the following parameters:
 |:--:|:--:|:--|
 |type|required|The result of GitHub Actions job<br>This parameter value must contain `success`, `fail` or `cancel`<br>We recommend using ${{ job.status }}|
 |job_name|required|Means slack notification title|
-|icon_emoji|optional|Slack icon<br>default: github|
-|username|optional|Slack username<br>default: Github Actions|
-|channel|optional|Slack channel name<br>When you does not specify, we use the channel that is set in Slack Incoming Webhook|
+|icon_emoji|optional|Slack icon<br>default: follow Slack Incoming Webhook settings|
+|username|optional|Slack username<br>default: follow Slack Incoming Webhook settings|
+|channel|optional|Slack channel name<br>default: follow Slack Incoming Webhook settings|
 |url|optional|Slack Incoming Webhooks URL<br>Please specify this key or SLACK_WEBHOOK environment variable<br>※SLACK_WEBHOOK will be deprecated|
 
 Please refer `action.yml` for more details.

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,8 @@ async function run() {
   try {
     const type: string = core.getInput('type', { required: true });
     const job_name: string = core.getInput('job_name', { required: true });
-    const username: string = core.getInput('username') || 'Github Actions';
-    const icon_emoji: string = core.getInput('icon_emoji') || 'github';
+    const username: string = core.getInput('username');
+    const icon_emoji: string = core.getInput('icon_emoji');
     const channel: string = core.getInput('channel');
     const url: string = core.getInput('url') || process.env.SLACK_WEBHOOK || '';
 


### PR DESCRIPTION
`username` と `icon_emoji` を指定しないと、incoming webhookの値を使ってくれそうです
こちらの方が便利に思ったのですが、いかがでしょうか？

↑：現在の挙動、↓未指定の場合の挙動

![image](https://user-images.githubusercontent.com/20282867/64918985-5e860b80-d7e0-11e9-9b40-1d8248c24f28.png)
