### PR TITLE
Upgrade to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     description: 'need to get commit data'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'bell'


### PR DESCRIPTION
When I use `lazy-actions/slatify` , I will get the following deprecation warning

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: lazy-actions/slatify
```

So I upgraded to node16.

This works on my repository

* https://github.com/sue445/gitpanda/pull/1040
* https://github.com/sue445/gitpanda/actions/runs/3246764724/jobs/5325901950